### PR TITLE
Add hatch-requirements-txt 0.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,34 +10,40 @@ source:
   sha256: bb87ecee32e4ac05d09854ac3c279dd526fbd655154acd9cd10c2a4768a83669
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   number: 0
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
-    - hatchling >=0.21.0
+    - hatchling
+    - wheel
   run:
-    - python >=3.6
+    - python
     - hatchling >=0.21.0
     - packaging >=21.3
 
 test:
   imports:
     - hatch_requirements_txt
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/repo-helper/hatch-requirements-txt
   summary: Hatchling plugin to read project dependencies from requirements.txt
   license: MIT
+  license_family: MIT
   license_file:
     - LICENSE
+  description: |
+    This is a plugin for Hatchling that reads the project dependencies from a requirements.txt file.
+  dev_url: https://github.com/repo-helper/hatch-requirements-txt
+  doc_url: https://github.com/repo-helper/hatch-requirements-txt
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Releases: https://github.com/repo-helper/hatch-requirements-txt/releases
License: https://github.com/repo-helper/hatch-requirements-txt/blob/v0.3.0/LICENSE
Requirements:
- https://github.com/repo-helper/hatch-requirements-txt/blob/v0.3.0/pyproject.toml
- https://github.com/repo-helper/hatch-requirements-txt/blob/v0.3.0/requirements.txt

Actions:
1. Skip py<36
2. Fix python in host and run
3. Add --no-deps to script
4. Add license_family
5. Add description
6. Add dev and doc urls

Notes:
- `conda-lock` requires it for `host`