### PR TITLE
hatch-requirements-txt 0.4.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hatch-requirements-txt" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hatch_requirements_txt-{{ version }}.tar.gz
-  sha256: bb87ecee32e4ac05d09854ac3c279dd526fbd655154acd9cd10c2a4768a83669
+  sha256: 2c686e5758fd05bb55fa7d0c198fdd481f8d3aaa3c693260f5c0d74ce3547d20
 
 build:
+  # Technically we should be [py<361] for 0.4.1 but conda doesn't
+  # recognise 361 and skips all pythons...
   skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,14 +18,17 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6.1  # see skip, above
     - pip
     - hatchling
     - wheel
   run:
-    - python
+    - python >=3.6.1  # see skip, above
     - hatchling >=0.21.0
     - packaging >=21.3
+
+# No upstream tests (in GH repo) as we are missing coincidence,
+# coverage-pyver-pragma, dist-meta, domdf-python-tools.
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,14 +18,16 @@ build:
 
 requirements:
   host:
-    - python >=3.6.1  # see skip, above
+    - python
     - pip
     - hatchling
     - wheel
   run:
-    - python >=3.6.1  # see skip, above
+    - python
     - hatchling >=0.21.0
     - packaging >=21.3
+  run_constrained:
+    - python >=3.6.1  # see skip, above
 
 # No upstream tests (in GH repo) as we are missing coincidence,
 # coverage-pyver-pragma, dist-meta, domdf-python-tools.


### PR DESCRIPTION
hatch-requirements-txt 0.4.1 

**Destination channel:** Defaults

### Links

- [PKG-5430]
- dev_url:        https://github.com/repo-helper/hatch-requirements-txt/tree/v0.4.1
- conda_forge:    https://github.com/conda-forge/hatch-requirements-txt-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/hatch-requirements-txt/0.4.1
- pypi inspector: https://inspector.pypi.io/project/hatch-requirements-txt/0.4.1

### Explanation of changes:

- new version number
- No upstream tests (in GH repo) as we are missing `coincidence`, `coverage-pyver-pragma`, `dist-meta`, `domdf-python-tools`


[PKG-5430]: https://anaconda.atlassian.net/browse/PKG-5430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ